### PR TITLE
Bump version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+simple-obfs (0.0.3-1) unstable; urgency=medium
+
+  * Add failover option.
+  * Minor bug fixes.
+
+ -- Max Lv <max.c.lv@gmail.com>  Fri, 17 Mar 2017 17:02:43 +0800
+
 simple-obfs (0.0.2-1) UNRELEASED; urgency=low
 
   * Initial release. (Closes: #)


### PR DESCRIPTION
Update version number to `0.0.3`.
Otherwise it remains `0.0.2` while building under Debian.