### PR TITLE
Make the HTTP obfuscation work behind an NGINX reverse proxy

### DIFF
--- a/src/obfs.h
+++ b/src/obfs.h
@@ -23,6 +23,7 @@
 #ifndef OBFS_H
 #define OBFS_H
 
+#include <stdbool.h>
 #include "encrypt.h"
 
 #define OBFS_OK         0
@@ -40,6 +41,7 @@ typedef struct obfs_para {
     const char *name;
     const char *host;
     uint16_t port;
+    bool send_empty_response_upon_connection;
 
     int(*const obfs_request)(buffer_t *, size_t, obfs_t *);
     int(*const obfs_response)(buffer_t *, size_t, obfs_t *);

--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -62,6 +62,8 @@ static int next_header(const char **, int *);
 static obfs_para_t obfs_http_st = {
     .name            = "http",
     .port            = 80,
+    .send_empty_response_upon_connection = true,
+
     .obfs_request    = &obfs_http_request,
     .obfs_response   = &obfs_http_response,
     .deobfs_request  = &deobfs_http_header,
@@ -165,7 +167,8 @@ deobfs_http_header(buffer_t *buf, size_t cap, obfs_t *obfs)
     int len    = buf->len;
     int err    = -1;
 
-    while (len > 4) {
+    // Allow empty content
+    while (len >= 4) {
         if (data[0] == '\r' && data[1] == '\n'
             && data[2] == '\r' && data[3] == '\n') {
             len  -= 4;

--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -38,6 +38,7 @@ static const char *http_request_template =
     "Upgrade: websocket\r\n"
     "Connection: Upgrade\r\n"
     "Sec-WebSocket-Key: %s\r\n"
+    "Content-Length: %lu\r\n"
     "\r\n";
 
 static const char *http_response_template =
@@ -103,7 +104,7 @@ obfs_http_request(buffer_t *buf, size_t cap, obfs_t *obfs)
 
     size_t obfs_len =
         snprintf(http_header, sizeof(http_header), http_request_template,
-                 host_port, major_version, minor_version, b64);
+                 host_port, major_version, minor_version, b64, buf->len);
     size_t buf_len = buf->len;
 
     brealloc(buf, obfs_len + buf_len, cap);

--- a/src/obfs_tls.c
+++ b/src/obfs_tls.c
@@ -177,6 +177,8 @@ static int is_enable_tls(obfs_t *obfs);
 static obfs_para_t obfs_tls_st = {
     .name            = "tls",
     .port            = 443,
+    .send_empty_response_upon_connection = false,
+
     .obfs_request    = &obfs_tls_request,
     .obfs_response   = &obfs_tls_response,
     .deobfs_request  = &deobfs_tls_request,

--- a/src/server.c
+++ b/src/server.c
@@ -477,7 +477,6 @@ perform_handshake(EV_P_ server_t *server)
             }
 
             // waiting on remote connected event
-            ev_io_stop(EV_A_ & server->recv_ctx->io);
             ev_io_start(EV_A_ & remote->send_ctx->io);
         }
     } else {
@@ -490,7 +489,6 @@ perform_handshake(EV_P_ server_t *server)
         server->query = resolv_query(host, server_resolve_cb,
                                         query_free_cb, query, port);
 
-        ev_io_stop(EV_A_ & server->recv_ctx->io);
     }
 
     return;
@@ -567,6 +565,8 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
         }
 
         server->stage = STAGE_HANDSHAKE;
+        ev_io_stop(EV_A_ & server->recv_ctx->io);
+
         // Copy the first packet to the currently unused header_buf.
         server->header_buf->len = server->buf->len - server->buf->idx;
         server->header_buf->idx = 0;


### PR DESCRIPTION
Changed the following things:
1. Added `Content-Length` header to the initial HTTP request.
2. Make the `http` obfuscator respond immediately after request.