### PR TITLE
Update json code to shadowsocks-libev master, fix segfault.

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -28,975 +28,984 @@
  */
 
 #include "json.h"
-#include "utils.h"
 
 #ifdef _MSC_VER
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
+   #ifndef _CRT_SECURE_NO_WARNINGS
+      #define _CRT_SECURE_NO_WARNINGS
+   #endif
 #endif
 
-#ifdef __cplusplus
-const struct _json_value json_value_none; /* zero-d by ctor */
-#else
-const struct _json_value json_value_none = { NULL, 0, { 0 }, { NULL } };
-#endif
+const struct _json_value json_value_none;
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
 
-typedef unsigned short json_uchar;
+typedef unsigned int json_uchar;
 
-static unsigned char
-hex_value(json_char c)
+static unsigned char hex_value (json_char c)
 {
-    if (isdigit((uint8_t)c)) {
-        return c - '0';
-    }
+   if (isdigit(c))
+      return c - '0';
 
-    switch (c) {
-    case 'a':
-    case 'A':
-        return 0x0A;
-    case 'b':
-    case 'B':
-        return 0x0B;
-    case 'c':
-    case 'C':
-        return 0x0C;
-    case 'd':
-    case 'D':
-        return 0x0D;
-    case 'e':
-    case 'E':
-        return 0x0E;
-    case 'f':
-    case 'F':
-        return 0x0F;
-    default:
-        return 0xFF;
-    }
+   switch (c) {
+      case 'a': case 'A': return 0x0A;
+      case 'b': case 'B': return 0x0B;
+      case 'c': case 'C': return 0x0C;
+      case 'd': case 'D': return 0x0D;
+      case 'e': case 'E': return 0x0E;
+      case 'f': case 'F': return 0x0F;
+      default: return 0xFF;
+   }
 }
 
-typedef struct {
-    unsigned long used_memory;
+typedef struct
+{
+   unsigned long used_memory;
 
-    unsigned int uint_max;
-    unsigned long ulong_max;
+   unsigned int uint_max;
+   unsigned long ulong_max;
 
-    json_settings settings;
-    int first_pass;
+   json_settings settings;
+   int first_pass;
+
+   const json_char * ptr;
+   unsigned int cur_line, cur_col;
+
 } json_state;
 
-static void *
-default_alloc(size_t size, int zero, void *user_data)
+static void * default_alloc (size_t size, int zero, void * user_data)
 {
-    return zero ? calloc(1, size) : ss_malloc(size);
+   return zero ? calloc (1, size) : malloc (size);
 }
 
-static void
-default_free(void *ptr, void *user_data)
+static void default_free (void * ptr, void * user_data)
 {
-    ss_free(ptr);
+   free (ptr);
 }
 
-static void *
-json_alloc(json_state *state, unsigned long size, int zero)
+static void * json_alloc (json_state * state, unsigned long size, int zero)
 {
-    if ((state->ulong_max - state->used_memory) < size) {
-        return 0;
-    }
+   if ((state->ulong_max - state->used_memory) < size)
+      return 0;
 
-    if (state->settings.max_memory
-        && (state->used_memory += size) > state->settings.max_memory) {
-        return 0;
-    }
+   if (state->settings.max_memory
+         && (state->used_memory += size) > state->settings.max_memory)
+   {
+      return 0;
+   }
 
-    return state->settings.mem_alloc(size, zero, state->settings.user_data);
+   return state->settings.mem_alloc (size, zero, state->settings.user_data);
 }
 
-static int
-new_value(json_state *state, json_value **top, json_value **root,
-          json_value **alloc, json_type type)
+static int new_value (json_state * state,
+                      json_value ** top, json_value ** root, json_value ** alloc,
+                      json_type type)
 {
-    json_value *value;
-    int values_size;
+   json_value * value;
+   int values_size;
 
-    if (!state->first_pass) {
-        value  = *top = *alloc;
-        *alloc = (*alloc)->_reserved.next_alloc;
+   if (!state->first_pass)
+   {
+      value = *top = *alloc;
+      *alloc = (*alloc)->_reserved.next_alloc;
 
-        if (!*root) {
-            *root = value;
-        }
+      if (!*root)
+         *root = value;
 
-        switch (value->type) {
-        case json_array:
+      switch (value->type)
+      {
+         case json_array:
 
-            if (!(value->u.array.values = (json_value **)json_alloc
-                                              (state, value->u.array.length *
-                                              sizeof(json_value *), 0))) {
-                return 0;
+            if (value->u.array.length == 0)
+               break;
+
+            if (! (value->u.array.values = (json_value **) json_alloc
+               (state, value->u.array.length * sizeof (json_value *), 0)) )
+            {
+               return 0;
             }
 
             value->u.array.length = 0;
             break;
 
-        case json_object:
+         case json_object:
 
-            values_size = sizeof(*value->u.object.values) *
-                          value->u.object.length;
+            if (value->u.object.length == 0)
+               break;
 
-            if (!((*(void **)&value->u.object.values) = json_alloc
-                                                            (state,
-                                                            values_size +
-                                                            ((size_t)value->u.
-                                                             object.values),
-                                                            0))) {
-                return 0;
+            values_size = sizeof (*value->u.object.values) * value->u.object.length;
+
+            if (! (value->u.object.values = (json_object_entry *) json_alloc
+                  (state, values_size + ((unsigned long) value->u.object.values), 0)) )
+            {
+               return 0;
             }
 
-            value->_reserved.object_mem = (*(char **)&value->u.object.values) +
-                                          values_size;
+            value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;
 
             value->u.object.length = 0;
             break;
 
-        case json_string:
+         case json_string:
 
-            if (!(value->u.string.ptr = (json_char *)json_alloc
-                                            (state,
-                                            (value->u.string.length +
-                                             1) * sizeof(json_char), 0))) {
-                return 0;
+            if (! (value->u.string.ptr = (json_char *) json_alloc
+               (state, (value->u.string.length + 1) * sizeof (json_char), 0)) )
+            {
+               return 0;
             }
 
             value->u.string.length = 0;
             break;
 
-        default:
+         default:
             break;
-        }
+      };
 
-        return 1;
-    }
+      return 1;
+   }
 
-    value = (json_value *)json_alloc(state, sizeof(json_value), 1);
+   if (! (value = (json_value *) json_alloc
+         (state, sizeof (json_value) + state->settings.value_extra, 1)))
+   {
+      return 0;
+   }
 
-    if (!value) {
-        return 0;
-    }
+   if (!*root)
+      *root = value;
 
-    if (!*root) {
-        *root = value;
-    }
+   value->type = type;
+   value->parent = *top;
 
-    value->type   = type;
-    value->parent = *top;
+   #ifdef JSON_TRACK_SOURCE
+      value->line = state->cur_line;
+      value->col = state->cur_col;
+   #endif
 
-    if (*alloc) {
-        (*alloc)->_reserved.next_alloc = value;
-    }
+   if (*alloc)
+      (*alloc)->_reserved.next_alloc = value;
 
-    *alloc = *top = value;
+   *alloc = *top = value;
 
-    return 1;
+   return 1;
 }
 
-#define e_off \
-    ((int)(i - cur_line_begin))
+#define whitespace \
+   case '\n': ++ state.cur_line;  state.cur_col = 0; \
+   case ' ': case '\t': case '\r'
 
-#define whitespace                          \
-case '\n': \
-    ++cur_line; cur_line_begin = i; \
-case ' ': \
-case '\t': \
-case '\r'
+#define string_add(b)  \
+   do { if (!state.first_pass) string [string_length] = b;  ++ string_length; } while (0);
 
-#define string_add(b)                                         \
-    do { if (!state.first_pass) { string[string_length] = b; \
-         } ++string_length; } while (0)
+#define line_and_col \
+   state.cur_line, state.cur_col
 
 static const long
-    flag_next           = 1 << 0,
-    flag_reproc         = 1 << 1,
-    flag_need_comma     = 1 << 2,
-    flag_seek_value     = 1 << 3,
-    flag_escaped        = 1 << 4,
-    flag_string         = 1 << 5,
-    flag_need_colon     = 1 << 6,
-    flag_done           = 1 << 7,
-    flag_num_negative   = 1 << 8,
-    flag_num_zero       = 1 << 9,
-    flag_num_e          = 1 << 10,
-    flag_num_e_got_sign = 1 << 11,
-    flag_num_e_negative = 1 << 12,
-    flag_line_comment   = 1 << 13,
-    flag_block_comment  = 1 << 14;
+   flag_next             = 1 << 0,
+   flag_reproc           = 1 << 1,
+   flag_need_comma       = 1 << 2,
+   flag_seek_value       = 1 << 3, 
+   flag_escaped          = 1 << 4,
+   flag_string           = 1 << 5,
+   flag_need_colon       = 1 << 6,
+   flag_done             = 1 << 7,
+   flag_num_negative     = 1 << 8,
+   flag_num_zero         = 1 << 9,
+   flag_num_e            = 1 << 10,
+   flag_num_e_got_sign   = 1 << 11,
+   flag_num_e_negative   = 1 << 12,
+   flag_line_comment     = 1 << 13,
+   flag_block_comment    = 1 << 14;
 
-json_value *
-json_parse_ex(json_settings *settings,
-              const json_char *json,
-              size_t length,
-              char *error_buf)
+json_value * json_parse_ex (json_settings * settings,
+                            const json_char * json,
+                            size_t length,
+                            char * error_buf)
 {
-    json_char error[json_error_max];
-    int cur_line;
-    const json_char *cur_line_begin, *i, *end;
-    json_value *top, *root, *alloc = 0;
-    json_state state = { 0UL, 0U, 0UL, { 0UL, 0, NULL, NULL, NULL }, 0 };
-    long flags;
-    long num_digits = 0, num_e = 0;
-    json_int_t num_fraction = 0;
+   json_char error [json_error_max];
+   const json_char * end;
+   json_value * top, * root, * alloc = 0;
+   json_state state = { 0 };
+   long flags;
+   long num_digits = 0, num_e = 0;
+   json_int_t num_fraction = 0;
 
-    /* Skip UTF-8 BOM
-     */
-    if (length >= 3 && ((unsigned char)json[0]) == 0xEF
-        && ((unsigned char)json[1]) == 0xBB
-        && ((unsigned char)json[2]) == 0xBF) {
-        json   += 3;
-        length -= 3;
-    }
+   /* Skip UTF-8 BOM
+    */
+   if (length >= 3 && ((unsigned char) json [0]) == 0xEF
+                   && ((unsigned char) json [1]) == 0xBB
+                   && ((unsigned char) json [2]) == 0xBF)
+   {
+      json += 3;
+      length -= 3;
+   }
 
-    error[0] = '\0';
-    end      = (json + length);
+   error[0] = '\0';
+   end = (json + length);
 
-    memcpy(&state.settings, settings, sizeof(json_settings));
+   memcpy (&state.settings, settings, sizeof (json_settings));
 
-    if (!state.settings.mem_alloc) {
-        state.settings.mem_alloc = default_alloc;
-    }
+   if (!state.settings.mem_alloc)
+      state.settings.mem_alloc = default_alloc;
 
-    if (!state.settings.mem_free) {
-        state.settings.mem_free = default_free;
-    }
+   if (!state.settings.mem_free)
+      state.settings.mem_free = default_free;
 
-    memset(&state.uint_max, 0xFF, sizeof(state.uint_max));
-    memset(&state.ulong_max, 0xFF, sizeof(state.ulong_max));
+   memset (&state.uint_max, 0xFF, sizeof (state.uint_max));
+   memset (&state.ulong_max, 0xFF, sizeof (state.ulong_max));
 
-    state.uint_max  -= 8; /* limit of how much can be added before next check */
-    state.ulong_max -= 8;
+   state.uint_max -= 8; /* limit of how much can be added before next check */
+   state.ulong_max -= 8;
 
-    for (state.first_pass = 1; state.first_pass >= 0; --state.first_pass) {
-        json_uchar uchar;
-        unsigned char uc_b1, uc_b2, uc_b3, uc_b4;
-        json_char *string          = 0;
-        unsigned int string_length = 0;
+   for (state.first_pass = 1; state.first_pass >= 0; -- state.first_pass)
+   {
+      json_uchar uchar;
+      unsigned char uc_b1, uc_b2, uc_b3, uc_b4;
+      json_char * string = 0;
+      unsigned int string_length = 0;
 
-        top   = root = 0;
-        flags = flag_seek_value;
+      top = root = 0;
+      flags = flag_seek_value;
 
-        cur_line       = 1;
-        cur_line_begin = json;
+      state.cur_line = 1;
 
-        for (i = json;; ++i) {
-            json_char b = (i == end ? 0 : *i);
+      for (state.ptr = json ;; ++ state.ptr)
+      {
+         json_char b = (state.ptr == end ? 0 : *state.ptr);
+         
+         if (flags & flag_string)
+         {
+            if (!b)
+            {  sprintf (error, "Unexpected EOF in string (at %d:%d)", line_and_col);
+               goto e_failed;
+            }
 
-            if (flags & flag_string) {
-                if (!b) {
-                    sprintf(error, "Unexpected EOF in string (at %d:%d)",
-                            cur_line, e_off);
-                    goto e_failed;
-                }
+            if (string_length > state.uint_max)
+               goto e_overflow;
 
-                if (string_length > state.uint_max) {
-                    goto e_overflow;
-                }
+            if (flags & flag_escaped)
+            {
+               flags &= ~ flag_escaped;
 
-                if (flags & flag_escaped) {
-                    flags &= ~flag_escaped;
+               switch (b)
+               {
+                  case 'b':  string_add ('\b');  break;
+                  case 'f':  string_add ('\f');  break;
+                  case 'n':  string_add ('\n');  break;
+                  case 'r':  string_add ('\r');  break;
+                  case 't':  string_add ('\t');  break;
+                  case 'u':
 
-                    switch (b) {
-                    case 'b':
-                        string_add('\b');
-                        break;
-                    case 'f':
-                        string_add('\f');
-                        break;
-                    case 'n':
-                        string_add('\n');
-                        break;
-                    case 'r':
-                        string_add('\r');
-                        break;
-                    case 't':
-                        string_add('\t');
-                        break;
-                    case 'u':
+                    if (end - state.ptr < 4 || 
+                        (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
+                    {
+                        sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                        goto e_failed;
+                    }
 
-                        if (end - i < 4 ||
-                            (uc_b1 = hex_value(*++i)) == 0xFF ||
-                            (uc_b2 = hex_value(*++i)) == 0xFF
-                            || (uc_b3 = hex_value(*++i)) == 0xFF ||
-                            (uc_b4 = hex_value(*++i)) == 0xFF) {
-                            sprintf(error,
-                                    "Invalid character value `%c` (at %d:%d)",
-                                    b, cur_line, e_off);
+                    uc_b1 = (uc_b1 << 4) | uc_b2;
+                    uc_b2 = (uc_b3 << 4) | uc_b4;
+                    uchar = (uc_b1 << 8) | uc_b2;
+
+                    if ((uchar & 0xF800) == 0xD800) {
+                        json_uchar uchar2;
+                        
+                        if (end - state.ptr < 6 || (*++ state.ptr) != '\\' || (*++ state.ptr) != 'u' ||
+                            (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
+                        {
+                            sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
                             goto e_failed;
                         }
 
-                        uc_b1 = uc_b1 * 16 + uc_b2;
-                        uc_b2 = uc_b3 * 16 + uc_b4;
+                        uc_b1 = (uc_b1 << 4) | uc_b2;
+                        uc_b2 = (uc_b3 << 4) | uc_b4;
+                        uchar2 = (uc_b1 << 8) | uc_b2;
+                        
+                        uchar = 0x010000 | ((uchar & 0x3FF) << 10) | (uchar2 & 0x3FF);
+                    }
 
-                        uchar = ((json_char)uc_b1) * 256 + uc_b2;
+                    if (sizeof (json_char) >= sizeof (json_uchar) || (uchar <= 0x7F))
+                    {
+                       string_add ((json_char) uchar);
+                       break;
+                    }
 
-                        if (sizeof(json_char) >= sizeof(json_uchar) ||
-                            (uc_b1 == 0 && uc_b2 <= 0x7F)) {
-                            string_add((json_char)uchar);
-                            break;
-                        }
-
-                        if (uchar <= 0x7FF) {
-                            if (state.first_pass) {
-                                string_length += 2;
-                            } else {
-                                string[string_length++] = 0xC0 |
-                                                          ((uc_b2 &
-                                                            0xC0) >>
-                                                           6) |
-                                                          ((uc_b1 & 0x7) << 2);
-                                string[string_length++] = 0x80 |
-                                                          (uc_b2 & 0x3F);
-                            }
-
-                            break;
-                        }
-
-                        if (state.first_pass) {
-                            string_length += 3;
-                        } else {
-                            string[string_length++] = 0xE0 |
-                                                      ((uc_b1 & 0xF0) >> 4);
-                            string[string_length++] = 0x80 |
-                                                      ((uc_b1 &
-                                                        0xF) <<
-                                                       2) |
-                                                      ((uc_b2 & 0xC0) >> 6);
-                            string[string_length++] = 0x80 | (uc_b2 & 0x3F);
+                    if (uchar <= 0x7FF)
+                    {
+                        if (state.first_pass)
+                           string_length += 2;
+                        else
+                        {  string [string_length ++] = 0xC0 | (uchar >> 6);
+                           string [string_length ++] = 0x80 | (uchar & 0x3F);
                         }
 
                         break;
-
-                    default:
-                        string_add(b);
                     }
 
-                    continue;
-                }
-
-                if (b == '\\') {
-                    flags |= flag_escaped;
-                    continue;
-                }
-
-                if (b == '"') {
-                    if (!state.first_pass) {
-                        string[string_length] = 0;
-                    }
-
-                    flags &= ~flag_string;
-                    string = 0;
-
-                    switch (top->type) {
-                    case json_string:
-
-                        top->u.string.length = string_length;
-                        flags               |= flag_next;
-
-                        break;
-
-                    case json_object:
-
-                        if (state.first_pass) {
-                            (*(json_char **)&top->u.object.values) +=
-                                string_length + 1;
-                        } else {
-                            top->u.object.values[top->u.object.length].name
-                                = (json_char *)top->_reserved.object_mem;
-
-                            top->u.object.values[top->u.object.length].
-                            name_length
-                                = string_length;
-
-                            (*(json_char **)&top->_reserved.object_mem) +=
-                                string_length + 1;
+                    if (uchar <= 0xFFFF) {
+                        if (state.first_pass)
+                           string_length += 3;
+                        else
+                        {  string [string_length ++] = 0xE0 | (uchar >> 12);
+                           string [string_length ++] = 0x80 | ((uchar >> 6) & 0x3F);
+                           string [string_length ++] = 0x80 | (uchar & 0x3F);
                         }
-
-                        flags |= flag_seek_value | flag_need_colon;
-                        continue;
-
-                    default:
+                        
                         break;
                     }
-                } else {
-                    string_add(b);
-                    continue;
-                }
-            }
 
-            if (state.settings.settings & json_enable_comments) {
-                if (flags & (flag_line_comment | flag_block_comment)) {
-                    if (flags & flag_line_comment) {
-                        if (b == '\r' || b == '\n' || !b) {
-                            flags &= ~flag_line_comment;
-                            --i;   /* so null can be reproc'd */
-                        }
-
-                        continue;
-                    }
-
-                    if (flags & flag_block_comment) {
-                        if (!b) {
-                            sprintf(error,
-                                    "%d:%d: Unexpected EOF in block comment",
-                                    cur_line, e_off);
-                            goto e_failed;
-                        }
-
-                        if (b == '*' && i < (end - 1) && i[1] == '/') {
-                            flags &= ~flag_block_comment;
-                            ++i;   /* skip closing sequence */
-                        }
-
-                        continue;
-                    }
-                } else if (b == '/') {
-                    if (!(flags & (flag_seek_value | flag_done)) && top->type !=
-                        json_object) {
-                        sprintf(error, "%d:%d: Comment not allowed here",
-                                cur_line, e_off);
-                        goto e_failed;
-                    }
-
-                    if (++i == end) {
-                        sprintf(error, "%d:%d: EOF unexpected", cur_line,
-                                e_off);
-                        goto e_failed;
-                    }
-
-                    switch (b = *i) {
-                    case '/':
-                        flags |= flag_line_comment;
-                        continue;
-
-                    case '*':
-                        flags |= flag_block_comment;
-                        continue;
-
-                    default:
-                        sprintf(error,
-                                "%d:%d: Unexpected `%c` in comment opening sequence", cur_line, e_off,
-                                b);
-                        goto e_failed;
-                    }
-                }
-            }
-
-            if (flags & flag_done) {
-                if (!b) {
-                    break;
-                }
-
-                switch (b) {
-whitespace:
-                    continue;
-
-                default:
-                    sprintf(error, "%d:%d: Trailing garbage: `%c`", cur_line,
-                            e_off, b);
-                    goto e_failed;
-                }
-            }
-
-            if (flags & flag_seek_value) {
-                switch (b) {
-whitespace:
-                    continue;
-
-                case ']':
-
-                    if (top->type == json_array) {
-                        flags =
-                            (flags &
-                             ~(flag_need_comma | flag_seek_value)) | flag_next;
-                    } else {
-                        sprintf(error, "%d:%d: Unexpected ]", cur_line, e_off);
-                        goto e_failed;
+                    if (state.first_pass)
+                       string_length += 4;
+                    else
+                    {  string [string_length ++] = 0xF0 | (uchar >> 18);
+                       string [string_length ++] = 0x80 | ((uchar >> 12) & 0x3F);
+                       string [string_length ++] = 0x80 | ((uchar >> 6) & 0x3F);
+                       string [string_length ++] = 0x80 | (uchar & 0x3F);
                     }
 
                     break;
 
-                default:
+                  default:
+                     string_add (b);
+               };
 
-                    if (flags & flag_need_comma) {
-                        if (b == ',') {
-                            flags &= ~flag_need_comma;
-                            continue;
-                        } else {
-                            sprintf(error, "%d:%d: Expected , before %c",
-                                    cur_line, e_off, b);
-                            goto e_failed;
-                        }
-                    }
+               continue;
+            }
 
-                    if (flags & flag_need_colon) {
-                        if (b == ':') {
-                            flags &= ~flag_need_colon;
-                            continue;
-                        } else {
-                            sprintf(error, "%d:%d: Expected : before %c",
-                                    cur_line, e_off, b);
-                            goto e_failed;
-                        }
-                    }
+            if (b == '\\')
+            {
+               flags |= flag_escaped;
+               continue;
+            }
 
-                    flags &= ~flag_seek_value;
+            if (b == '"')
+            {
+               if (!state.first_pass)
+                  string [string_length] = 0;
 
-                    switch (b) {
-                    case '{':
+               flags &= ~ flag_string;
+               string = 0;
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_object)) {
-                            goto e_alloc_failure;
-                        }
+               switch (top->type)
+               {
+                  case json_string:
+
+                     top->u.string.length = string_length;
+                     flags |= flag_next;
+
+                     break;
+
+                  case json_object:
+
+                     if (state.first_pass)
+                        (*(json_char **) &top->u.object.values) += string_length + 1;
+                     else
+                     {  
+                        top->u.object.values [top->u.object.length].name
+                           = (json_char *) top->_reserved.object_mem;
+
+                        top->u.object.values [top->u.object.length].name_length
+                           = string_length;
+
+                        (*(json_char **) &top->_reserved.object_mem) += string_length + 1;
+                     }
+
+                     flags |= flag_seek_value | flag_need_colon;
+                     continue;
+
+                  default:
+                     break;
+               };
+            }
+            else
+            {
+               string_add (b);
+               continue;
+            }
+         }
+
+         if (state.settings.settings & json_enable_comments)
+         {
+            if (flags & (flag_line_comment | flag_block_comment))
+            {
+               if (flags & flag_line_comment)
+               {
+                  if (b == '\r' || b == '\n' || !b)
+                  {
+                     flags &= ~ flag_line_comment;
+                     -- state.ptr;  /* so null can be reproc'd */
+                  }
+
+                  continue;
+               }
+
+               if (flags & flag_block_comment)
+               {
+                  if (!b)
+                  {  sprintf (error, "%d:%d: Unexpected EOF in block comment", line_and_col);
+                     goto e_failed;
+                  }
+
+                  if (b == '*' && state.ptr < (end - 1) && state.ptr [1] == '/')
+                  {
+                     flags &= ~ flag_block_comment;
+                     ++ state.ptr;  /* skip closing sequence */
+                  }
+
+                  continue;
+               }
+            }
+            else if (b == '/')
+            {
+               if (! (flags & (flag_seek_value | flag_done)) && top->type != json_object)
+               {  sprintf (error, "%d:%d: Comment not allowed here", line_and_col);
+                  goto e_failed;
+               }
+
+               if (++ state.ptr == end)
+               {  sprintf (error, "%d:%d: EOF unexpected", line_and_col);
+                  goto e_failed;
+               }
+
+               switch (b = *state.ptr)
+               {
+                  case '/':
+                     flags |= flag_line_comment;
+                     continue;
+
+                  case '*':
+                     flags |= flag_block_comment;
+                     continue;
+
+                  default:
+                     sprintf (error, "%d:%d: Unexpected `%c` in comment opening sequence", line_and_col, b);
+                     goto e_failed;
+               };
+            }
+         }
+
+         if (flags & flag_done)
+         {
+            if (!b)
+               break;
+
+            switch (b)
+            {
+               whitespace:
+                  continue;
+
+               default:
+
+                  sprintf (error, "%d:%d: Trailing garbage: `%c`",
+                           state.cur_line, state.cur_col, b);
+
+                  goto e_failed;
+            };
+         }
+
+         if (flags & flag_seek_value)
+         {
+            switch (b)
+            {
+               whitespace:
+                  continue;
+
+               case ']':
+
+                  if (top && top->type == json_array)
+                     flags = (flags & ~ (flag_need_comma | flag_seek_value)) | flag_next;
+                  else
+                  {  sprintf (error, "%d:%d: Unexpected ]", line_and_col);
+                     goto e_failed;
+                  }
+
+                  break;
+
+               default:
+
+                  if (flags & flag_need_comma)
+                  {
+                     if (b == ',')
+                     {  flags &= ~ flag_need_comma;
+                        continue;
+                     }
+                     else
+                     {
+                        sprintf (error, "%d:%d: Expected , before %c",
+                                 state.cur_line, state.cur_col, b);
+
+                        goto e_failed;
+                     }
+                  }
+
+                  if (flags & flag_need_colon)
+                  {
+                     if (b == ':')
+                     {  flags &= ~ flag_need_colon;
+                        continue;
+                     }
+                     else
+                     { 
+                        sprintf (error, "%d:%d: Expected : before %c",
+                                 state.cur_line, state.cur_col, b);
+
+                        goto e_failed;
+                     }
+                  }
+
+                  flags &= ~ flag_seek_value;
+
+                  switch (b)
+                  {
+                     case '{':
+
+                        if (!new_value (&state, &top, &root, &alloc, json_object))
+                           goto e_alloc_failure;
 
                         continue;
 
-                    case '[':
+                     case '[':
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_array)) {
-                            goto e_alloc_failure;
-                        }
+                        if (!new_value (&state, &top, &root, &alloc, json_array))
+                           goto e_alloc_failure;
 
                         flags |= flag_seek_value;
                         continue;
 
-                    case '"':
+                     case '"':
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_string)) {
-                            goto e_alloc_failure;
-                        }
+                        if (!new_value (&state, &top, &root, &alloc, json_string))
+                           goto e_alloc_failure;
 
                         flags |= flag_string;
 
-                        string        = top->u.string.ptr;
+                        string = top->u.string.ptr;
                         string_length = 0;
 
                         continue;
 
-                    case 't':
+                     case 't':
 
-                        if ((end - i) < 3 || *(++i) != 'r' || *(++i) != 'u' ||
-                            *(++i) != 'e') {
-                            goto e_unknown_value;
+                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'r' ||
+                            *(++ state.ptr) != 'u' || *(++ state.ptr) != 'e')
+                        {
+                           goto e_unknown_value;
                         }
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_boolean)) {
-                            goto e_alloc_failure;
-                        }
+                        if (!new_value (&state, &top, &root, &alloc, json_boolean))
+                           goto e_alloc_failure;
 
                         top->u.boolean = 1;
 
                         flags |= flag_next;
                         break;
 
-                    case 'f':
+                     case 'f':
 
-                        if ((end - i) < 4 || *(++i) != 'a' || *(++i) != 'l' ||
-                            *(++i) != 's' || *(++i) != 'e') {
-                            goto e_unknown_value;
+                        if ((end - state.ptr) < 4 || *(++ state.ptr) != 'a' ||
+                            *(++ state.ptr) != 'l' || *(++ state.ptr) != 's' ||
+                            *(++ state.ptr) != 'e')
+                        {
+                           goto e_unknown_value;
                         }
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_boolean)) {
-                            goto e_alloc_failure;
-                        }
+                        if (!new_value (&state, &top, &root, &alloc, json_boolean))
+                           goto e_alloc_failure;
 
                         flags |= flag_next;
                         break;
 
-                    case 'n':
+                     case 'n':
 
-                        if ((end - i) < 3 || *(++i) != 'u' || *(++i) != 'l' ||
-                            *(++i) != 'l') {
-                            goto e_unknown_value;
+                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'u' ||
+                            *(++ state.ptr) != 'l' || *(++ state.ptr) != 'l')
+                        {
+                           goto e_unknown_value;
                         }
 
-                        if (!new_value(&state, &top, &root, &alloc,
-                                       json_null)) {
-                            goto e_alloc_failure;
-                        }
+                        if (!new_value (&state, &top, &root, &alloc, json_null))
+                           goto e_alloc_failure;
 
                         flags |= flag_next;
                         break;
 
-                    default:
+                     default:
 
-                        if (isdigit((uint8_t)b) || b == '-') {
-                            if (!new_value(&state, &top, &root, &alloc,
-                                           json_integer)) {
-                                goto e_alloc_failure;
-                            }
+                        if (isdigit (b) || b == '-')
+                        {
+                           if (!new_value (&state, &top, &root, &alloc, json_integer))
+                              goto e_alloc_failure;
 
-                            if (!state.first_pass) {
-                                while (isdigit((uint8_t)b) || b == '+' || b ==
-                                       '-'
-                                       || b == 'e' || b == 'E' || b == '.') {
-                                    if ((++i) == end) {
-                                        b = 0;
-                                        break;
-                                    }
+                           if (!state.first_pass)
+                           {
+                              while (isdigit (b) || b == '+' || b == '-'
+                                        || b == 'e' || b == 'E' || b == '.')
+                              {
+                                 if ( (++ state.ptr) == end)
+                                 {
+                                    b = 0;
+                                    break;
+                                 }
 
-                                    b = *i;
-                                }
+                                 b = *state.ptr;
+                              }
 
-                                flags |= flag_next | flag_reproc;
-                                break;
-                            }
+                              flags |= flag_next | flag_reproc;
+                              break;
+                           }
 
-                            flags &= ~(flag_num_negative | flag_num_e |
-                                       flag_num_e_got_sign |
-                                       flag_num_e_negative |
-                                       flag_num_zero);
+                           flags &= ~ (flag_num_negative | flag_num_e |
+                                        flag_num_e_got_sign | flag_num_e_negative |
+                                           flag_num_zero);
 
-                            num_digits   = 0;
-                            num_fraction = 0;
-                            num_e        = 0;
+                           num_digits = 0;
+                           num_fraction = 0;
+                           num_e = 0;
 
-                            if (b != '-') {
-                                flags |= flag_reproc;
-                                break;
-                            }
+                           if (b != '-')
+                           {
+                              flags |= flag_reproc;
+                              break;
+                           }
 
-                            flags |= flag_num_negative;
-                            continue;
-                        } else {
-                            sprintf(error,
-                                    "%d:%d: Unexpected %c when seeking value",
-                                    cur_line, e_off, b);
-                            goto e_failed;
+                           flags |= flag_num_negative;
+                           continue;
                         }
-                    }
-                }
-            } else {
-                switch (top->type) {
-                case json_object:
-
-                    switch (b) {
-whitespace:
-                        continue;
-
-                    case '"':
-
-                        if (flags & flag_need_comma) {
-                            sprintf(error, "%d:%d: Expected , before \"",
-                                    cur_line, e_off);
-                            goto e_failed;
+                        else
+                        {  sprintf (error, "%d:%d: Unexpected %c when seeking value", line_and_col, b);
+                           goto e_failed;
                         }
+                  };
+            };
+         }
+         else
+         {
+            switch (top->type)
+            {
+            case json_object:
+               
+               switch (b)
+               {
+                  whitespace:
+                     continue;
 
-                        flags |= flag_string;
+                  case '"':
 
-                        string        = (json_char *)top->_reserved.object_mem;
-                        string_length = 0;
-
-                        break;
-
-                    case '}':
-
-                        flags = (flags & ~flag_need_comma) | flag_next;
-                        break;
-
-                    case ',':
-
-                        if (flags & flag_need_comma) {
-                            flags &= ~flag_need_comma;
-                            break;
-                        }
-
-                    default:
-
-                        sprintf(error, "%d:%d: Unexpected `%c` in object",
-                                cur_line, e_off, b);
+                     if (flags & flag_need_comma)
+                     {  sprintf (error, "%d:%d: Expected , before \"", line_and_col);
                         goto e_failed;
-                    }
+                     }
 
-                    break;
+                     flags |= flag_string;
 
-                case json_integer:
-                case json_double:
+                     string = (json_char *) top->_reserved.object_mem;
+                     string_length = 0;
 
-                    if (isdigit((uint8_t)b)) {
-                        ++num_digits;
+                     break;
+                  
+                  case '}':
 
-                        if (top->type == json_integer || flags & flag_num_e) {
-                            if (!(flags & flag_num_e)) {
-                                if (flags & flag_num_zero) {
-                                    sprintf(error,
-                                            "%d:%d: Unexpected `0` before `%c`",
-                                            cur_line, e_off, b);
-                                    goto e_failed;
-                                }
+                     flags = (flags & ~ flag_need_comma) | flag_next;
+                     break;
 
-                                if (num_digits == 1 && b == '0') {
-                                    flags |= flag_num_zero;
-                                }
-                            } else {
-                                flags |= flag_num_e_got_sign;
-                                num_e  = (num_e * 10) + (b - '0');
-                                continue;
-                            }
+                  case ',':
 
-                            top->u.integer = (top->u.integer * 10) + (b - '0');
-                            continue;
+                     if (flags & flag_need_comma)
+                     {
+                        flags &= ~ flag_need_comma;
+                        break;
+                     }
+
+                  default:
+                     sprintf (error, "%d:%d: Unexpected `%c` in object", line_and_col, b);
+                     goto e_failed;
+               };
+
+               break;
+
+            case json_integer:
+            case json_double:
+
+               if (isdigit (b))
+               {
+                  ++ num_digits;
+
+                  if (top->type == json_integer || flags & flag_num_e)
+                  {
+                     if (! (flags & flag_num_e))
+                     {
+                        if (flags & flag_num_zero)
+                        {  sprintf (error, "%d:%d: Unexpected `0` before `%c`", line_and_col, b);
+                           goto e_failed;
                         }
 
-                        num_fraction = (num_fraction * 10) + (b - '0');
+                        if (num_digits == 1 && b == '0')
+                           flags |= flag_num_zero;
+                     }
+                     else
+                     {
+                        flags |= flag_num_e_got_sign;
+                        num_e = (num_e * 10) + (b - '0');
                         continue;
-                    }
+                     }
 
-                    if (b == '+' || b == '-') {
-                        if ((flags & flag_num_e) &&
-                            !(flags & flag_num_e_got_sign)) {
-                            flags |= flag_num_e_got_sign;
+                     top->u.integer = (top->u.integer * 10) + (b - '0');
+                     continue;
+                  }
 
-                            if (b == '-') {
-                                flags |= flag_num_e_negative;
-                            }
+                  num_fraction = (num_fraction * 10) + (b - '0');
+                  continue;
+               }
 
-                            continue;
-                        }
-                    } else if (b == '.' && top->type == json_integer) {
-                        if (!num_digits) {
-                            sprintf(error, "%d:%d: Expected digit before `.`",
-                                    cur_line, e_off);
-                            goto e_failed;
-                        }
+               if (b == '+' || b == '-')
+               {
+                  if ( (flags & flag_num_e) && !(flags & flag_num_e_got_sign))
+                  {
+                     flags |= flag_num_e_got_sign;
 
-                        top->type  = json_double;
-                        top->u.dbl = (double)top->u.integer;
+                     if (b == '-')
+                        flags |= flag_num_e_negative;
 
-                        num_digits = 0;
-                        continue;
-                    }
+                     continue;
+                  }
+               }
+               else if (b == '.' && top->type == json_integer)
+               {
+                  if (!num_digits)
+                  {  sprintf (error, "%d:%d: Expected digit before `.`", line_and_col);
+                     goto e_failed;
+                  }
 
-                    if (!(flags & flag_num_e)) {
-                        if (top->type == json_double) {
-                            if (!num_digits) {
-                                sprintf(error,
-                                        "%d:%d: Expected digit after `.`",
-                                        cur_line, e_off);
-                                goto e_failed;
-                            }
+                  top->type = json_double;
+                  top->u.dbl = (double) top->u.integer;
 
-                            top->u.dbl += ((double)num_fraction) /
-                                          (pow(10, (double)num_digits));
-                        }
+                  num_digits = 0;
+                  continue;
+               }
 
-                        if (b == 'e' || b == 'E') {
-                            flags |= flag_num_e;
+               if (! (flags & flag_num_e))
+               {
+                  if (top->type == json_double)
+                  {
+                     if (!num_digits)
+                     {  sprintf (error, "%d:%d: Expected digit after `.`", line_and_col);
+                        goto e_failed;
+                     }
 
-                            if (top->type == json_integer) {
-                                top->type  = json_double;
-                                top->u.dbl = (double)top->u.integer;
-                            }
+                     top->u.dbl += ((double) num_fraction) / (pow (10.0, (double) num_digits));
+                  }
 
-                            num_digits = 0;
-                            flags     &= ~flag_num_zero;
+                  if (b == 'e' || b == 'E')
+                  {
+                     flags |= flag_num_e;
 
-                            continue;
-                        }
-                    } else {
-                        if (!num_digits) {
-                            sprintf(error, "%d:%d: Expected digit after `e`",
-                                    cur_line, e_off);
-                            goto e_failed;
-                        }
+                     if (top->type == json_integer)
+                     {
+                        top->type = json_double;
+                        top->u.dbl = (double) top->u.integer;
+                     }
 
-                        top->u.dbl *=
-                            pow(10,
-                                (double)((flags &
-                                         flag_num_e_negative) ? -num_e : num_e));
-                    }
+                     num_digits = 0;
+                     flags &= ~ flag_num_zero;
 
-                    if (flags & flag_num_negative) {
-                        if (top->type == json_integer) {
-                            top->u.integer = -top->u.integer;
-                        } else {
-                            top->u.dbl = -top->u.dbl;
-                        }
-                    }
+                     continue;
+                  }
+               }
+               else
+               {
+                  if (!num_digits)
+                  {  sprintf (error, "%d:%d: Expected digit after `e`", line_and_col);
+                     goto e_failed;
+                  }
 
-                    flags |= flag_next | flag_reproc;
-                    break;
+                  top->u.dbl *= pow (10.0, (double)
+                      (flags & flag_num_e_negative ? - num_e : num_e));
+               }
 
-                default:
-                    break;
-                }
+               if (flags & flag_num_negative)
+               {
+                  if (top->type == json_integer)
+                     top->u.integer = - top->u.integer;
+                  else
+                     top->u.dbl = - top->u.dbl;
+               }
+
+               flags |= flag_next | flag_reproc;
+               break;
+
+            default:
+               break;
+            };
+         }
+
+         if (flags & flag_reproc)
+         {
+            flags &= ~ flag_reproc;
+            -- state.ptr;
+         }
+
+         if (flags & flag_next)
+         {
+            flags = (flags & ~ flag_next) | flag_need_comma;
+
+            if (!top->parent)
+            {
+               /* root value done */
+
+               flags |= flag_done;
+               continue;
             }
 
-            if (flags & flag_reproc) {
-                flags &= ~flag_reproc;
-                --i;
-            }
+            if (top->parent->type == json_array)
+               flags |= flag_seek_value;
+               
+            if (!state.first_pass)
+            {
+               json_value * parent = top->parent;
 
-            if (flags & flag_next) {
-                flags = (flags & ~flag_next) | flag_need_comma;
+               switch (parent->type)
+               {
+                  case json_object:
 
-                if (!top->parent) {
-                    /* root value done */
-
-                    flags |= flag_done;
-                    continue;
-                }
-
-                if (top->parent->type == json_array) {
-                    flags |= flag_seek_value;
-                }
-
-                if (!state.first_pass) {
-                    json_value *parent = top->parent;
-
-                    switch (parent->type) {
-                    case json_object:
-
-                        parent->u.object.values
+                     parent->u.object.values
                         [parent->u.object.length].value = top;
 
-                        break;
+                     break;
 
-                    case json_array:
+                  case json_array:
 
-                        parent->u.array.values
-                        [parent->u.array.length] = top;
+                     parent->u.array.values
+                           [parent->u.array.length] = top;
 
-                        break;
+                     break;
 
-                    default:
-                        break;
-                    }
-                }
-
-                if ((++top->parent->u.array.length) > state.uint_max) {
-                    goto e_overflow;
-                }
-
-                top = top->parent;
-
-                continue;
+                  default:
+                     break;
+               };
             }
-        }
 
-        alloc = root;
-    }
+            if ( (++ top->parent->u.array.length) > state.uint_max)
+               goto e_overflow;
 
-    return root;
+            top = top->parent;
+
+            continue;
+         }
+      }
+
+      alloc = root;
+   }
+
+   return root;
 
 e_unknown_value:
 
-    sprintf(error, "%d:%d: Unknown value", cur_line, e_off);
-    goto e_failed;
+   sprintf (error, "%d:%d: Unknown value", line_and_col);
+   goto e_failed;
 
 e_alloc_failure:
 
-    strcpy(error, "Memory allocation failure");
-    goto e_failed;
+   strcpy (error, "Memory allocation failure");
+   goto e_failed;
 
 e_overflow:
 
-    sprintf(error, "%d:%d: Too long (caught overflow)", cur_line, e_off);
-    goto e_failed;
+   sprintf (error, "%d:%d: Too long (caught overflow)", line_and_col);
+   goto e_failed;
 
 e_failed:
 
-    if (error_buf) {
-        if (*error) {
-            strcpy(error_buf, error);
-        } else {
-            strcpy(error_buf, "Unknown error");
-        }
-    }
+   if (error_buf)
+   {
+      if (*error)
+         strcpy (error_buf, error);
+      else
+         strcpy (error_buf, "Unknown error");
+   }
 
-    if (state.first_pass) {
-        alloc = root;
-    }
+   if (state.first_pass)
+      alloc = root;
 
-    while (alloc) {
-        top = alloc->_reserved.next_alloc;
-        state.settings.mem_free(alloc, state.settings.user_data);
-        alloc = top;
-    }
+   while (alloc)
+   {
+      top = alloc->_reserved.next_alloc;
+      state.settings.mem_free (alloc, state.settings.user_data);
+      alloc = top;
+   }
 
-    if (!state.first_pass) {
-        json_value_free_ex(&state.settings, root);
-    }
+   if (!state.first_pass)
+      json_value_free_ex (&state.settings, root);
 
-    return 0;
+   return 0;
 }
 
-json_value *
-json_parse(const json_char *json, size_t length)
+json_value * json_parse (const json_char * json, size_t length)
 {
-    json_settings settings = { 0UL, 0, NULL, NULL, NULL };
-    return json_parse_ex(&settings, json, length, 0);
+   json_settings settings = { 0 };
+   return json_parse_ex (&settings, json, length, 0);
 }
 
-void
-json_value_free_ex(json_settings *settings, json_value *value)
+void json_value_free_ex (json_settings * settings, json_value * value)
 {
-    json_value *cur_value;
+   json_value * cur_value;
 
-    if (!value) {
-        return;
-    }
+   if (!value)
+      return;
 
-    value->parent = 0;
+   value->parent = 0;
 
-    while (value) {
-        switch (value->type) {
-        case json_array:
+   while (value)
+   {
+      switch (value->type)
+      {
+         case json_array:
 
-            if (!value->u.array.length) {
-                settings->mem_free(value->u.array.values, settings->user_data);
-                break;
+            if (!value->u.array.length)
+            {
+               settings->mem_free (value->u.array.values, settings->user_data);
+               break;
             }
 
-            value = value->u.array.values[--value->u.array.length];
+            value = value->u.array.values [-- value->u.array.length];
             continue;
 
-        case json_object:
+         case json_object:
 
-            if (!value->u.object.length) {
-                settings->mem_free(value->u.object.values, settings->user_data);
-                break;
+            if (!value->u.object.length)
+            {
+               settings->mem_free (value->u.object.values, settings->user_data);
+               break;
             }
 
-            value = value->u.object.values[--value->u.object.length].value;
+            value = value->u.object.values [-- value->u.object.length].value;
             continue;
 
-        case json_string:
+         case json_string:
 
-            settings->mem_free(value->u.string.ptr, settings->user_data);
+            settings->mem_free (value->u.string.ptr, settings->user_data);
             break;
 
-        default:
+         default:
             break;
-        }
+      };
 
-        cur_value = value;
-        value     = value->parent;
-        settings->mem_free(cur_value, settings->user_data);
-    }
+      cur_value = value;
+      value = value->parent;
+      settings->mem_free (cur_value, settings->user_data);
+   }
 }
 
-void
-json_value_free(json_value *value)
+void json_value_free (json_value * value)
 {
-    json_settings settings = { 0UL, 0, NULL, NULL, NULL };
-    settings.mem_free = default_free;
-    json_value_free_ex(&settings, value);
+   json_settings settings = { 0 };
+   settings.mem_free = default_free;
+   json_value_free_ex (&settings, value);
 }
+


### PR DESCRIPTION
The `src/json.c` and `src/json.h` in this project match the copies in `shadowsocks-libev`. The `shadowsocks-libev` versions [were recently updated](https://github.com/Windendless/shadowsocks-libev/commit/88f6d8eac32a447b902eb379afb6be3e6c2e05a7) to address a null pointer deref identified [through fuzzing](https://github.com/shadowsocks/shadowsocks-libev/issues/1594).

This PR updates the local `src/json.c` and `src/json.h` to match `shadowsocks-libev`'s copies to carry the null pointer deref fix to this project.

I verified that `simple-obfs`'s copies of this JSON code produced the same segfault as `shadowsocks-libev` using the repro & fuzz rig that @felixgr provided in https://github.com/shadowsocks/shadowsocks-libev/issues/1594 (Awesome work! Thank you!). It is only required to tweak the `src/Makefile.am` diff requested to specify `+json_fuzz_LDADD = $(OBFS_COMMON_LIBS)` instead of `SS_COMMON_LIBS`. Applying b84623c resolved the segfault from `json_fuzz` as it did with `shadowsocks-libev`.
