### PR TITLE
Missing dependency for c-ares for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ e.g. Ubuntu, Debian or Linux Mint, you can build the binary like this:
 # Debian / Ubuntu
 sudo apt-get install --no-install-recommends build-essential autoconf libtool libssl-dev libpcre3-dev libc-ares-dev libev-dev asciidoc xmlto automake
 # CentOS / Fedora / RHEL
-sudo yum install gcc autoconf libtool automake make zlib-devel openssl-devel asciidoc xmlto
+sudo yum install gcc autoconf libtool automake make zlib-devel openssl-devel asciidoc xmlto c-ares-devel
 # Arch
 sudo pacman -Syu gcc autoconf libtool automake make zlib openssl asciidoc xmlto
 


### PR DESCRIPTION
Original commit https://github.com/shadowsocks/simple-obfs/commit/63507530524ac011c8fb380c7b8fb7904769267a