### PR TITLE
Add url path specifying support.

### DIFF
--- a/doc/obfs-local.asciidoc
+++ b/doc/obfs-local.asciidoc
@@ -85,6 +85,9 @@ Enable HTTP or TLS obfuscating. (Experimental)
 --obfs-host <hostname>::
 Specify the hostname for obfuscating. (Experimental)
 
+--obfs-uri <uri>::
+Specify the HTTP path uri for obfuscating. (Experimental)
+
 -v::
 Enable verbose mode.
 

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -184,6 +184,8 @@ read_jconf(const char *file)
                 conf.obfs = to_string(value);
             } else if (strcmp(name, "obfs_host") == 0) {
                 conf.obfs_host = to_string(value);
+            } else if (strcmp(name, "obfs_uri") == 0) {
+                conf.obfs_uri = to_string(value);
             } else if (strcmp(name, "failover") == 0) {
                 conf.failover = to_string(value);
             } else if (strcmp(name, "fast_open") == 0) {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -51,6 +51,7 @@ typedef struct {
     char *user;
     char *obfs;
     char *obfs_host;
+    char *obfs_uri;
     char *failover;
     int fast_open;
     int nofile;

--- a/src/local.c
+++ b/src/local.c
@@ -878,7 +878,8 @@ main(int argc, char **argv)
     char *pid_path   = NULL;
     char *conf_path  = NULL;
     char *iface      = NULL;
-    char *obfs_host   = NULL;
+    char *obfs_host  = NULL;
+    char *obfs_uri   = NULL;
 
     srand(time(NULL));
 
@@ -962,6 +963,8 @@ main(int argc, char **argv)
                         obfs_para = obfs_tls;
                 } else if (strcmp(key, "obfs-host") == 0) {
                     obfs_host = value;
+                } else if (strcmp(key, "obfs-uri") == 0) {
+                    obfs_uri = value;
 #ifdef __linux__
                 } else if (strcmp(key, "mptcp") == 0) {
                     mptcp = 1;
@@ -979,6 +982,7 @@ main(int argc, char **argv)
         { "mptcp",     no_argument,       0, 0 },
         { "obfs",      required_argument, 0, 0 },
         { "obfs-host", required_argument, 0, 0 },
+        { "obfs-uri",  required_argument, 0, 0 },
         { "help",      no_argument,       0, 0 },
         { 0,           0,                 0, 0 }
     };
@@ -1009,6 +1013,8 @@ main(int argc, char **argv)
             } else if (option_index == 3) {
                 obfs_host = optarg;
             } else if (option_index == 4) {
+                obfs_uri = optarg;
+            } else if (option_index == 5) {
                 usage();
                 exit(EXIT_SUCCESS);
             }
@@ -1107,6 +1113,9 @@ main(int argc, char **argv)
         if (obfs_host == NULL) {
             obfs_host = conf->obfs_host;
         }
+        if (obfs_uri == NULL) {
+            obfs_uri = conf->obfs_uri;
+        }
         if (fast_open == 0) {
             fast_open = conf->fast_open;
         }
@@ -1173,10 +1182,13 @@ main(int argc, char **argv)
             obfs_para->host = obfs_host;
         else
             obfs_para->host = "cloudfront.net";
+        if (obfs_uri == NULL) obfs_para->uri = "/";
+        else obfs_para->uri = obfs_uri;
         obfs_para->port = atoi(remote_port);
         LOGI("obfuscating enabled");
         if (obfs_host)
             LOGI("obfuscating hostname: %s", obfs_host);
+        if (obfs_uri) LOGI("obfuscation uri path: %s", obfs_uri);
     }
 
 #ifdef __MINGW32__

--- a/src/obfs.h
+++ b/src/obfs.h
@@ -40,6 +40,7 @@ typedef struct obfs {
 typedef struct obfs_para {
     const char *name;
     const char *host;
+    const char *uri;
     uint16_t port;
     bool send_empty_response_upon_connection;
 

--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -32,7 +32,7 @@
 #include "obfs_http.h"
 
 static const char *http_request_template =
-    "GET / HTTP/1.1\r\n"
+    "GET %s HTTP/1.1\r\n"
     "Host: %s\r\n"
     "User-Agent: curl/7.%d.%d\r\n"
     "Upgrade: websocket\r\n"
@@ -104,7 +104,7 @@ obfs_http_request(buffer_t *buf, size_t cap, obfs_t *obfs)
 
     size_t obfs_len =
         snprintf(http_header, sizeof(http_header), http_request_template,
-                 host_port, major_version, minor_version, b64, buf->len);
+                 obfs_http->uri, host_port, major_version, minor_version, b64, buf->len);
     size_t buf_len = buf->len;
 
     brealloc(buf, obfs_len + buf_len, cap);

--- a/src/utils.c
+++ b/src/utils.c
@@ -273,6 +273,8 @@ usage()
 #ifndef MODULE_REMOTE
     printf(
         "       --obfs-host <host_name>    Hostname for obfuscating (Experimental).\n");
+    printf(
+        "       --obfs-uri <uri_path>      HTTP path uri for obfuscating (Experimental).\n");
 #endif
     printf("\n");
     printf(


### PR DESCRIPTION
Specify `obfs-uri` can change the client request path uri.
eg: `"plugin_opts": "obfs=http;obfs-host=example.com;obfs-uri=/url-path"`