### PR TITLE
Port latest MinGW changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,12 +72,6 @@ case $host in
     AC_MSG_RESULT(Linux)
     ;;
   *-mingw*)
-    dnl Add custom macros for libev
-    AC_DEFINE([FD_SETSIZE], [2048], [Reset max file descriptor size.])
-    AC_DEFINE([EV_FD_TO_WIN32_HANDLE(fd)], [(fd)], [Override libev default fd conversion macro.])
-    AC_DEFINE([EV_WIN32_HANDLE_TO_FD(handle)], [(handle)], [Override libev default handle conversion macro.])
-    AC_DEFINE([EV_WIN32_CLOSE_FD(fd)], [closesocket(fd)], [Override libev default fd close macro.])
-
     os_support=mingw
     AC_MSG_RESULT(MinGW)
     ;;
@@ -146,7 +140,7 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 case $host in
   *-mingw*)
     AC_DEFINE([CONNECT_IN_PROGRESS], [WSAEWOULDBLOCK], [errno for incomplete non-blocking connect(2)])
-    AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h], [], [AC_MSG_ERROR([Missing MinGW headers])], [])
+    AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h mswsock.h], [], [AC_MSG_ERROR([Missing MinGW headers])], [])
     ;;
   *-linux*)
     AC_DEFINE([CONNECT_IN_PROGRESS], [EINPROGRESS], [errno for incomplete non-blocking connect(2)])
@@ -201,36 +195,17 @@ AC_FUNC_SELECT_ARGTYPES
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS([memset select setresuid setreuid strerror getpwnam_r setrlimit])
 
-dnl Check for select() into ws2_32 for Msys/Mingw
-if test "$ac_cv_func_select" != "yes"; then
-  AC_MSG_CHECKING([for select in ws2_32])
-  AC_TRY_LINK([
-#ifdef HAVE_WINSOCK2_H
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <winsock2.h>
-#endif
-    ],[
-      select(0,(fd_set *)NULL,(fd_set *)NULL,(fd_set *)NULL,(struct timeval *)NULL);
-    ],[
-      AC_MSG_RESULT([yes])
-      HAVE_SELECT="1"
-      AC_DEFINE_UNQUOTED(HAVE_SELECT, 1,
-        [Define to 1 if you have the 'select' function.])
-      HAVE_SYS_SELECT_H="1"
-      AC_DEFINE_UNQUOTED(HAVE_SYS_SELECT_H, 1,
-        [Define to 1 if you have the <sys/select.h> header file.])
-    ],[
-      AC_MSG_ERROR([no])
-  ])
-fi
-
 AC_CHECK_LIB(socket, connect)
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS([malloc memset socket])
 
+AC_ARG_WITH(ev,
+  AS_HELP_STRING([--with-ev=DIR], [use a specific libev library]),
+  [CFLAGS="$CFLAGS -I$withval/include"
+   CPPFLAGS="$CPPFLAGS -I$withval/include"
+   LDFLAGS="$LDFLAGS -L$withval/lib"]
+)
 AC_CHECK_LIB([ev], [ev_loop_destroy], [LIBS="-lev $LIBS"], [AC_MSG_ERROR([Couldn't find libev. Try installing libev-dev@<:@el@:>@.])])
 
 AM_COND_IF([ENABLE_DOCUMENTATION],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,9 +10,7 @@ OBFS_COMMON_LIBS = $(top_builddir)/libcork/libcork.la \
 OBFS_COMMON_LIBS += -lev -lm
 
 bin_PROGRAMS = obfs-local
-if !BUILD_WINCOMPAT
 bin_PROGRAMS += obfs-server
-endif
 
 obfs_src = obfs_http.c \
 		   obfs_tls.c \
@@ -43,4 +41,5 @@ obfs_server_CFLAGS = $(AM_CFLAGS) -DMODULE_REMOTE
 
 if BUILD_WINCOMPAT
 obfs_local_SOURCES += win32.c
+obfs_server_SOURCES += win32.c
 endif

--- a/src/local.h
+++ b/src/local.h
@@ -26,6 +26,10 @@
 #include <ev.h>
 #include <libcork/ds.h>
 
+#ifdef __MINGW32__
+#include "win32.h"
+#endif
+
 #include "encrypt.h"
 #include "jconf.h"
 
@@ -77,6 +81,10 @@ typedef struct remote {
     int direct;
     int addr_len;
     uint32_t counter;
+#ifdef TCP_FASTOPEN_WINSOCK
+    OVERLAPPED olap;
+    int connect_ex_done;
+#endif
 
     buffer_t *buf;
     struct remote_ctx *recv_ctx;

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -23,6 +23,10 @@
 #ifndef _NETUTILS_H
 #define _NETUTILS_H
 
+#ifdef __MINGW32__
+#include "win32.h"
+#endif
+
 #if defined(__linux__)
 #include <netdb.h>
 #elif !defined(__MINGW32__)
@@ -39,10 +43,6 @@
 /*  conditional define for MSG_FASTOPEN */
 #ifndef MSG_FASTOPEN
 #define MSG_FASTOPEN   0x20000000
-#endif
-#elif !defined(__APPLE__)
-#ifdef TCP_FASTOPEN
-#undef TCP_FASTOPEN
 #endif
 #endif
 

--- a/src/server.c
+++ b/src/server.c
@@ -119,6 +119,7 @@ uint64_t rx                  = 0;
 
 static struct cork_dllist connections;
 
+#ifndef __MINGW32__
 static void
 parent_watcher_cb(EV_P_ ev_timer *watcher, int revents)
 {
@@ -133,6 +134,7 @@ parent_watcher_cb(EV_P_ ev_timer *watcher, int revents)
 
     ppid = cur_ppid;
 }
+#endif
 
 static void
 free_connections(struct ev_loop *loop)
@@ -152,7 +154,7 @@ setfastopen(int fd)
     int s = 0;
 #ifdef TCP_FASTOPEN
     if (fast_open) {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MINGW32__)
         int opt = 1;
 #else
         int opt = 5;
@@ -348,6 +350,49 @@ connect_to_remote(EV_P_ struct addrinfo *res,
                          &iov, 1, &len, NULL);
         if (s == 0) {
             s = len;
+        }
+#elif defined(TCP_FASTOPEN_WINSOCK)
+        DWORD s = -1;
+        DWORD err = 0;
+        do {
+            int optval = 1;
+            // Set fast open option
+            if (setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN,
+                           &optval, sizeof(optval)) != 0) {
+                ERROR("setsockopt");
+                break;
+            }
+            // Load ConnectEx function
+            LPFN_CONNECTEX ConnectEx = winsock_getconnectex();
+            if (ConnectEx == NULL) {
+                LOGE("Cannot load ConnectEx() function");
+                err = WSAENOPROTOOPT;
+                break;
+            }
+            // ConnectEx requires a bound socket
+            if (winsock_dummybind(sockfd, res->ai_addr) != 0) {
+                ERROR("bind");
+                break;
+            }
+            // Call ConnectEx to send data
+            memset(&remote->olap, 0, sizeof(remote->olap));
+            remote->connect_ex_done = 0;
+            if (ConnectEx(sockfd, res->ai_addr, res->ai_addrlen,
+                          server->buf->data, server->buf->len,
+                          &s, &remote->olap)) {
+                remote->connect_ex_done = 1;
+                break;
+            };
+            // XXX: ConnectEx pending, check later in remote_send
+            if (WSAGetLastError() == ERROR_IO_PENDING) {
+                err = CONNECT_IN_PROGRESS;
+                break;
+            }
+            ERROR("ConnectEx");
+        } while(0);
+        // Set error number
+        if (err) {
+            SetLastError(err);
         }
 #else
         ssize_t s = sendto(sockfd, server->buf->data + server->buf->idx,
@@ -809,6 +854,37 @@ remote_send_cb(EV_P_ ev_io *w, int revents)
     }
 
     if (!remote_send_ctx->connected) {
+#ifdef TCP_FASTOPEN_WINSOCK
+        if (fast_open) {
+            // Check if ConnectEx is done
+            if (!remote->connect_ex_done) {
+                DWORD numBytes;
+                DWORD flags;
+                // Non-blocking way to fetch ConnectEx result
+                if (WSAGetOverlappedResult(remote->fd, &remote->olap,
+                                           &numBytes, FALSE, &flags)) {
+                    remote->buf->len -= numBytes;
+                    remote->buf->idx  = numBytes;
+                    remote->connect_ex_done = 1;
+                } else if (WSAGetLastError() == WSA_IO_INCOMPLETE) {
+                    // XXX: ConnectEx still not connected, wait for next time
+                    return;
+                } else {
+                    ERROR("WSAGetOverlappedResult");
+                    // not connected
+                    close_and_free_remote(EV_A_ remote);
+                    close_and_free_server(EV_A_ server);
+                    return;
+                };
+            }
+
+            // Make getpeername work
+            if (setsockopt(remote->fd, SOL_SOCKET,
+                           SO_UPDATE_CONNECT_CONTEXT, NULL, 0) != 0) {
+                ERROR("setsockopt");
+            }
+        }
+#endif
         struct sockaddr_storage addr;
         socklen_t len = sizeof(struct sockaddr_storage);
         memset(&addr, 0, len);
@@ -1478,9 +1554,11 @@ main(int argc, char **argv)
     // Init connections
     cork_dllist_init(&connections);
 
+#ifndef __MINGW32__
     ev_timer parent_watcher;
     ev_timer_init(&parent_watcher, parent_watcher_cb, 0, UPDATE_INTERVAL);
     ev_timer_start(EV_DEFAULT, &parent_watcher);
+#endif
 
     // start ev loop
     ev_run(loop, 0);

--- a/src/server.h
+++ b/src/server.h
@@ -27,6 +27,10 @@
 #include <time.h>
 #include <libcork/ds.h>
 
+#ifdef __MINGW32__
+#include "win32.h"
+#endif
+
 #include "encrypt.h"
 #include "jconf.h"
 
@@ -76,6 +80,10 @@ typedef struct remote_ctx {
 
 typedef struct remote {
     int fd;
+#ifdef TCP_FASTOPEN_WINSOCK
+    OVERLAPPED olap;
+    int connect_ex_done;
+#endif
     buffer_t *buf;
     struct remote_ctx *recv_ctx;
     struct remote_ctx *send_ctx;

--- a/src/utils.h
+++ b/src/utils.h
@@ -120,7 +120,7 @@ extern FILE *logfile;
         time_t now = time(NULL);                                            \
         char timestr[20];                                                   \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now));                \
-        fprintf(stderr, "%s [simple-obfs] INFO: " format "\n", timestr, ## __VA_ARGS__); \
+        fprintf(stderr, " %s [simple-obfs] INFO: " format "\n", timestr, ## __VA_ARGS__); \
         fflush(stderr); }                                                   \
     while (0)
 
@@ -129,7 +129,7 @@ extern FILE *logfile;
         time_t now = time(NULL);                                             \
         char timestr[20];                                                    \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now));                 \
-        fprintf(stderr, "%s [simple-obfs] ERROR: " format "\n", timestr, ## __VA_ARGS__); \
+        fprintf(stderr, " %s [simple-obfs] ERROR: " format "\n", timestr, ## __VA_ARGS__); \
         fflush(stderr); }                                                    \
     while (0)
 
@@ -202,6 +202,7 @@ extern int use_syslog;
 #undef ERROR
 #endif
 #define ERROR(s) ss_error(s)
+void ss_error(const char *s); // Implemented in win32.c
 
 #else
 

--- a/src/win32.c
+++ b/src/win32.c
@@ -1,7 +1,7 @@
 /*
- * win32.c - Win32 port helpers
+ * win32.c - Windows socket compatibility layer
  *
- * Copyright (C) 2014, Linus Yang <linusyang@gmail.com>
+ * Copyright (C) 2013 - 2018, Max Lv <max.c.lv@gmail.com>
  *
  * This file is part of the simple-obfs.
  *
@@ -20,40 +20,47 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifdef __MINGW32__
+
 #include "win32.h"
 #include "utils.h"
-#include <ctype.h>
-#include <stdint.h>
 
-#ifdef setsockopt
-#undef setsockopt
+#ifndef ENABLE_QUICK_EDIT
+#define ENABLE_QUICK_EDIT 0x0040
 #endif
 
-int
-clock_gettime(clockid_t id, struct timespec *spec)
+#ifndef STD_INPUT_HANDLE
+#define STD_INPUT_HANDLE ((DWORD)-10)
+#endif
+
+static void
+disable_quick_edit(void)
 {
-    __int64 wintime; GetSystemTimeAsFileTime((FILETIME*)&wintime);
-    wintime      -= 116444736000000000LL;           //1jan1601 to 1jan1970
-    spec->tv_sec  = wintime / 10000000LL;           //seconds
-    spec->tv_nsec = wintime % 10000000LL * 100;     //nano-seconds
-    return 0;
+    DWORD mode = 0;
+    HANDLE console = GetStdHandle(STD_INPUT_HANDLE);
+
+    // Get current console mode
+    if (console == NULL || !GetConsoleMode(console, &mode)) {
+        return;
+    }
+
+    // Clear the quick edit bit in the mode flags
+    mode &= ~ENABLE_QUICK_EDIT;
+    mode |= ENABLE_EXTENDED_FLAGS;
+    SetConsoleMode(console, mode);
 }
 
 void
 winsock_init(void)
 {
-    WORD wVersionRequested;
-    WSADATA wsaData;
     int ret;
-    wVersionRequested = MAKEWORD(1, 1);
-    ret               = WSAStartup(wVersionRequested, &wsaData);
+    WSADATA wsa_data;
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
     if (ret != 0) {
-        FATAL("Could not initialize winsock");
+        FATAL("Failed to initialize winsock");
     }
-    if (LOBYTE(wsaData.wVersion) != 1 || HIBYTE(wsaData.wVersion) != 1) {
-        WSACleanup();
-        FATAL("Could not find a usable version of winsock");
-    }
+    // Disable quick edit mode to prevent stuck
+    disable_quick_edit();
 }
 
 void
@@ -62,220 +69,91 @@ winsock_cleanup(void)
     WSACleanup();
 }
 
+int
+setnonblocking(SOCKET socket)
+{
+    u_long arg = 1;
+    return ioctlsocket(socket, FIONBIO, &arg);
+}
+
 void
 ss_error(const char *s)
 {
-    LPVOID *msg = NULL;
+    char *msg = NULL;
+    DWORD err = WSAGetLastError();
     FormatMessage(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, WSAGetLastError(),
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, err,
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
         (LPTSTR)&msg, 0, NULL);
     if (msg != NULL) {
-        LOGE("%s: %s", s, (char *)msg);
+        // Remove trailing newline character
+        ssize_t len = strlen(msg) - 1;
+        if (len >= 0 && msg[len] == '\n') {
+            msg[len] = '\0';
+        }
+        LOGE("%s: [%ld] %s", s, err, msg);
         LocalFree(msg);
     }
 }
 
-int
-setnonblocking(int fd)
+#ifdef TCP_FASTOPEN_WINSOCK
+LPFN_CONNECTEX
+winsock_getconnectex(void)
 {
-    u_long iMode = 1;
-    long int iResult;
-    iResult = ioctlsocket(fd, FIONBIO, &iMode);
-    if (iResult != NO_ERROR) {
-        LOGE("ioctlsocket failed with error: %ld\n", iResult);
+    static LPFN_CONNECTEX pConnectEx = NULL;
+    if (pConnectEx != NULL) {
+        return pConnectEx;
     }
-    return iResult;
-}
 
-size_t
-strnlen(const char *s, size_t maxlen)
-{
-    const char *end = memchr(s, 0, maxlen);
-    return end ? (size_t)(end - s) : maxlen;
-}
-
-const char *
-inet_ntop(int af, const void *src, char *dst, socklen_t size)
-{
-    struct sockaddr_storage ss;
-    unsigned long s = size;
-    ZeroMemory(&ss, sizeof(ss));
-    ss.ss_family = af;
-    switch (af) {
-    case AF_INET:
-        ((struct sockaddr_in *)&ss)->sin_addr = *(struct in_addr *)src;
-        break;
-    case AF_INET6:
-        ((struct sockaddr_in6 *)&ss)->sin6_addr = *(struct in6_addr *)src;
-        break;
-    default:
+    // Dummy socket for WSAIoctl
+    SOCKET s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == INVALID_SOCKET) {
+        ERROR("socket");
         return NULL;
     }
-    return (WSAAddressToString((struct sockaddr *)&ss, sizeof(ss), NULL, dst,
-                               &s) == 0) ? dst : NULL;
-}
 
-#define NS_INADDRSZ  4
-#define NS_IN6ADDRSZ 16
-#define NS_INT16SZ   2
-
-int
-inet_pton4(const char *src, char *dst)
-{
-    uint8_t tmp[NS_INADDRSZ], *tp;
-
-    int saw_digit = 0;
-    int octets = 0;
-    *(tp = tmp) = 0;
-
-    int ch;
-    while ((ch = *src++) != '\0')
-    {
-        if (ch >= '0' && ch <= '9')
-        {
-            uint32_t n = *tp * 10 + (ch - '0');
-
-            if (saw_digit && *tp == 0)
-                return 0;
-
-            if (n > 255)
-                return 0;
-
-            *tp = n;
-            if (!saw_digit)
-            {
-                if (++octets > 4)
-                    return 0;
-                saw_digit = 1;
-            }
-        }
-        else if (ch == '.' && saw_digit)
-        {
-            if (octets == 4)
-                return 0;
-            *++tp = 0;
-            saw_digit = 0;
-        }
-        else
-            return 0;
+    // Load ConnectEx function
+    GUID guid = WSAID_CONNECTEX;
+    DWORD numBytes;
+    int ret = -1;
+    ret = WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER,
+                   (void *)&guid, sizeof(guid),
+                   (void *)&pConnectEx, sizeof(pConnectEx),
+                   &numBytes, NULL, NULL);
+    if (ret != 0) {
+        ERROR("WSAIoctl");
+        closesocket(s);
+        return NULL;
     }
-    if (octets < 4)
-        return 0;
-
-    memcpy(dst, tmp, NS_INADDRSZ);
-
-    return 1;
+    closesocket(s);
+    return pConnectEx;
 }
 
 int
-inet_pton6(const char *src, char *dst)
+winsock_dummybind(SOCKET fd, struct sockaddr *sa)
 {
-    static const char xdigits[] = "0123456789abcdef";
-    uint8_t tmp[NS_IN6ADDRSZ];
-
-    uint8_t *tp = (uint8_t*) memset(tmp, '\0', NS_IN6ADDRSZ);
-    uint8_t *endp = tp + NS_IN6ADDRSZ;
-    uint8_t *colonp = NULL;
-
-    /* Leading :: requires some special handling. */
-    if (*src == ':')
-    {
-        if (*++src != ':')
-            return 0;
+    struct sockaddr_storage ss;
+    memset(&ss, 0, sizeof(ss));
+    if (sa->sa_family == AF_INET) {
+        struct sockaddr_in *sin = (struct sockaddr_in *)&ss;
+        sin->sin_family = AF_INET;
+        sin->sin_addr.s_addr = INADDR_ANY;
+    } else if (sa->sa_family == AF_INET6) {
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&ss;
+        sin6->sin6_family = AF_INET6;
+        sin6->sin6_addr = in6addr_any;
+    } else {
+        return -1;
     }
-
-    const char *curtok = src;
-    int saw_xdigit = 0;
-    uint32_t val = 0;
-    int ch;
-    while ((ch = tolower(*src++)) != '\0')
-    {
-        const char *pch = strchr(xdigits, ch);
-        if (pch != NULL)
-        {
-            val <<= 4;
-            val |= (pch - xdigits);
-            if (val > 0xffff)
-                return 0;
-            saw_xdigit = 1;
-            continue;
-        }
-        if (ch == ':')
-        {
-            curtok = src;
-            if (!saw_xdigit)
-            {
-                if (colonp)
-                    return 0;
-                colonp = tp;
-                continue;
-            }
-            else if (*src == '\0')
-            {
-                return 0;
-            }
-            if (tp + NS_INT16SZ > endp)
-                return 0;
-            *tp++ = (uint8_t) (val >> 8) & 0xff;
-            *tp++ = (uint8_t) val & 0xff;
-            saw_xdigit = 0;
-            val = 0;
-            continue;
-        }
-        if (ch == '.' && ((tp + NS_INADDRSZ) <= endp) &&
-                inet_pton4(curtok, (char*) tp) > 0)
-        {
-            tp += NS_INADDRSZ;
-            saw_xdigit = 0;
-            break; /* '\0' was seen by inet_pton4(). */
-        }
-        return 0;
+    if (bind(fd, (struct sockaddr *)&ss, sizeof(ss)) < 0 &&
+        WSAGetLastError() != WSAEINVAL) {
+        return -1;
     }
-    if (saw_xdigit)
-    {
-        if (tp + NS_INT16SZ > endp)
-            return 0;
-        *tp++ = (uint8_t) (val >> 8) & 0xff;
-        *tp++ = (uint8_t) val & 0xff;
-    }
-    if (colonp != NULL)
-    {
-        /*
-         * Since some memmove()'s erroneously fail to handle
-         * overlapping regions, we'll do the shift by hand.
-         */
-        const int n = tp - colonp;
-
-        if (tp == endp)
-            return 0;
-
-        for (int i = 1; i <= n; i++)
-        {
-            endp[-i] = colonp[n - i];
-            colonp[n - i] = 0;
-        }
-        tp = endp;
-    }
-    if (tp != endp)
-        return 0;
-
-    memcpy(dst, tmp, NS_IN6ADDRSZ);
-
-    return 1;
+    return 0;
 }
+#endif
 
-int
-inet_pton(int af, const char *src, void *dst)
-{
-    switch (af)
-    {
-        case AF_INET:
-            return inet_pton4(src, dst);
-        case AF_INET6:
-            return inet_pton6(src, dst);
-        default:
-            return -1;
-    }
-}
+#endif // __MINGW32__


### PR DESCRIPTION
Backport all recent changes on MinGW ports in main repository, including

* New libev backend powered by wepoll.
* New Windows compatibility layer targeted at NT6.
* TCP Fast Open support for Windows 10, 1607 or later.