### PR TITLE
failover need set port

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Only applicable on the server:
 
 ```bash
 # HTTP only with plugin mode
-ss-server -c config.json --plugin obfs-server --plugin-opts "obfs=http;failover=example.com"
+ss-server -c config.json --plugin obfs-server --plugin-opts "obfs=http;failover=example.com:80"
 
 # Both HTTP and HTTPS with standalone mode
-obfs-server -s server_ip -p 80 --obfs http -r 127.0.0.1:8388 --failover example.com
-obfs-server -s server_ip -p 443 --obfs tls -r 127.0.0.1:8388 --failover example.com
+obfs-server -s server_ip -p 80 --obfs http -r 127.0.0.1:8388 --failover example.com:80
+obfs-server -s server_ip -p 443 --obfs tls -r 127.0.0.1:8388 --failover example.com:443
 
 # suppose you have an HTTP webserver (apache/nginx/whatever) listening on localhost:8080 and HTTPS on 8443
 # (you probably shouldn't expose these ports)


### PR DESCRIPTION
当前最新版的obfs-server（0.0.5），当设置failover不指定端口时，failover无效，并且客户端无论是否使用混淆插件都能连接到服务器。加上端口后则恢复正常。
故推测这个端口号必须要填。
