### PR TITLE
Update obfs-server.asciidoc

### DIFF
--- a/doc/obfs-server.asciidoc
+++ b/doc/obfs-server.asciidoc
@@ -79,11 +79,6 @@ Enable Multipath TCP.
 +
 Only available with MPTCP enabled Linux kernel.
 
---mptcp::
-Enable Multipath TCP.
-+
-Only available with MPTCP enabled Linux kernel.
-
 --obfs <http|tls>::
 Enable HTTP or TLS obfuscating. (Experimental)
 


### PR DESCRIPTION
Remove dups.

Option `--mptcp` was documented twice.