### PR TITLE
Add config for http obfs request method.

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -186,6 +186,8 @@ read_jconf(const char *file)
                 conf.obfs_host = to_string(value);
             } else if (strcmp(name, "obfs_uri") == 0) {
                 conf.obfs_uri = to_string(value);
+            } else if (strcmp(name, "http_method") == 0) {
+                conf.http_method = to_string(value);
             } else if (strcmp(name, "failover") == 0) {
                 conf.failover = to_string(value);
             } else if (strcmp(name, "fast_open") == 0) {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -52,6 +52,7 @@ typedef struct {
     char *obfs;
     char *obfs_host;
     char *obfs_uri;
+    char *http_method;
     char *failover;
     int fast_open;
     int nofile;

--- a/src/local.c
+++ b/src/local.c
@@ -946,6 +946,7 @@ main(int argc, char **argv)
     char *iface      = NULL;
     char *obfs_host  = NULL;
     char *obfs_uri   = NULL;
+    char *http_method= NULL;
 
     srand(time(NULL));
 
@@ -1031,6 +1032,8 @@ main(int argc, char **argv)
                     obfs_host = value;
                 } else if (strcmp(key, "obfs-uri") == 0) {
                     obfs_uri = value;
+                } else if (strcmp(key, "http-method") == 0) {
+                    http_method = value;
 #ifdef __linux__
                 } else if (strcmp(key, "mptcp") == 0) {
                     mptcp = 1;
@@ -1049,6 +1052,7 @@ main(int argc, char **argv)
         { "obfs",      required_argument, 0, 0 },
         { "obfs-host", required_argument, 0, 0 },
         { "obfs-uri",  required_argument, 0, 0 },
+        { "http-method",required_argument,0, 0 },
         { "help",      no_argument,       0, 0 },
         { 0,           0,                 0, 0 }
     };
@@ -1081,6 +1085,8 @@ main(int argc, char **argv)
             } else if (option_index == 4) {
                 obfs_uri = optarg;
             } else if (option_index == 5) {
+                http_method = optarg;
+            } else if (option_index == 6) {
                 usage();
                 exit(EXIT_SUCCESS);
             }
@@ -1182,6 +1188,9 @@ main(int argc, char **argv)
         if (obfs_uri == NULL) {
             obfs_uri = conf->obfs_uri;
         }
+        if (http_method == NULL) {
+            http_method = conf->http_method;
+        }
         if (fast_open == 0) {
             fast_open = conf->fast_open;
         }
@@ -1250,8 +1259,11 @@ main(int argc, char **argv)
             obfs_para->host = "cloudfront.net";
         if (obfs_uri == NULL) obfs_para->uri = "/";
         else obfs_para->uri = obfs_uri;
+        if (http_method == NULL) obfs_para->method = "GET";
+        else obfs_para->method = http_method;
         obfs_para->port = atoi(remote_port);
         LOGI("obfuscating enabled");
+        LOGI("obfuscation http method: %s", obfs_para->method);
         if (obfs_host)
             LOGI("obfuscating hostname: %s", obfs_host);
         if (obfs_uri) LOGI("obfuscation uri path: %s", obfs_uri);

--- a/src/obfs.h
+++ b/src/obfs.h
@@ -41,6 +41,7 @@ typedef struct obfs_para {
     const char *name;
     const char *host;
     const char *uri;
+    const char *method;
     uint16_t port;
     bool send_empty_response_upon_connection;
 

--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -198,8 +198,7 @@ check_http_header(buffer_t *buf)
 
     if (len < 4)
         return OBFS_NEED_MORE;
-    int method_len = sizeof(obfs_http->method);
-    if (strncasecmp(data, obfs_http->method, method_len) != 0)
+    if (strncasecmp(data, obfs_http->method, strlen(obfs_http->method)) != 0)
         return OBFS_ERROR;
 
     {

--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -32,7 +32,7 @@
 #include "obfs_http.h"
 
 static const char *http_request_template =
-    "GET %s HTTP/1.1\r\n"
+    "%s %s HTTP/1.1\r\n"
     "Host: %s\r\n"
     "User-Agent: curl/7.%d.%d\r\n"
     "Upgrade: websocket\r\n"
@@ -103,7 +103,7 @@ obfs_http_request(buffer_t *buf, size_t cap, obfs_t *obfs)
     base64_encode(b64, 64, key, 16);
 
     size_t obfs_len =
-        snprintf(http_header, sizeof(http_header), http_request_template,
+        snprintf(http_header, sizeof(http_header), http_request_template, obfs_http->method,
                  obfs_http->uri, host_port, major_version, minor_version, b64, buf->len);
     size_t buf_len = buf->len;
 
@@ -198,8 +198,8 @@ check_http_header(buffer_t *buf)
 
     if (len < 4)
         return OBFS_NEED_MORE;
-
-    if (strncasecmp(data, "GET", 3) != 0)
+    int method_len = sizeof(obfs_http->method);
+    if (strncasecmp(data, obfs_http->method, method_len) != 0)
         return OBFS_ERROR;
 
     {

--- a/src/server.c
+++ b/src/server.c
@@ -1167,6 +1167,7 @@ main(int argc, char **argv)
     ss_addr_t failover = { .host = NULL, .port = NULL };
     char *failover_str = NULL;
     char *obfs_host = NULL;
+    char *http_method = NULL;
 
     char *ss_remote_host = getenv("SS_REMOTE_HOST");
     char *ss_remote_port = getenv("SS_REMOTE_PORT");
@@ -1241,6 +1242,8 @@ main(int argc, char **argv)
                         obfs_para = obfs_tls;
                 } else if (strcmp(key, "obfs-host") == 0) {
                     obfs_host = value;
+                } else if (strcmp(key, "http-method") == 0) {
+                    http_method = value;
                 } else if (strcmp(key, "failover") == 0) {
                     failover_str = value;
                 } else if (strcmp(key, "reverse_proxy") == 0) {
@@ -1261,6 +1264,7 @@ main(int argc, char **argv)
         { "help",            no_argument,       0, 0 },
         { "obfs",            required_argument, 0, 0 },
         { "obfs-host",       required_argument, 0, 0 },
+        { "http-method",     required_argument, 0, 0 },
         { "failover",        required_argument, 0, 0 },
 #ifdef __linux__
         { "mptcp",           no_argument,       0, 0 },
@@ -1290,11 +1294,13 @@ main(int argc, char **argv)
             } else if (option_index == 3) {
                 obfs_host = optarg;
             } else if (option_index == 4) {
-                failover_str = optarg;
+                http_method = optarg;
             } else if (option_index == 5) {
+                failover_str = optarg;
+            } else if (option_index == 6) {
                 mptcp = 1;
                 LOGI("enable multipath TCP");
-            } else if (option_index == 6) {
+            } else if (option_index == 7) {
                 reverse_proxy = 1;
                 LOGI("enable reverse proxy");
             }
@@ -1390,6 +1396,7 @@ main(int argc, char **argv)
         if (obfs_host == NULL) {
             obfs_host = conf->obfs_host;
         }
+        if (http_method == NULL) http_method = conf->http_method;
         if (mptcp == 0) {
             mptcp = conf->mptcp;
         }
@@ -1474,7 +1481,10 @@ main(int argc, char **argv)
 
     if (obfs_para) {
         obfs_para->host = obfs_host;
+        if (http_method == NULL) obfs_para->method = "GET";
+        else obfs_para->method = http_method;
         LOGI("obfuscating enabled");
+        LOGI("obfuscation http method: %s", obfs_para->method);
         if (obfs_host)
             LOGI("obfuscating hostname: %s", obfs_host);
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -270,9 +270,9 @@ usage()
 #endif
     printf(
         "       --obfs <http|tls>          Enable obfuscating: HTTP or TLS (Experimental).\n");
-#ifndef MODULE_REMOTE
     printf(
         "       --http-method <METHOD>     HTTP request method for obfuscating (Experimental).\n");
+#ifndef MODULE_REMOTE
     printf(
         "       --obfs-host <host_name>    Hostname for obfuscating (Experimental).\n");
     printf(

--- a/src/utils.c
+++ b/src/utils.c
@@ -272,6 +272,8 @@ usage()
         "       --obfs <http|tls>          Enable obfuscating: HTTP or TLS (Experimental).\n");
 #ifndef MODULE_REMOTE
     printf(
+        "       --http-method <METHOD>     HTTP request method for obfuscating (Experimental).\n");
+    printf(
         "       --obfs-host <host_name>    Hostname for obfuscating (Experimental).\n");
     printf(
         "       --obfs-uri <uri_path>      HTTP path uri for obfuscating (Experimental).\n");


### PR DESCRIPTION
The http request method can be specified using `--http-method`, this parameter must be the same on both client and server side.
for example:
```
obfs-server -s 127.0.0.1 -p 80 -r 127.0.0.1:8388 --obfs http --http-method POST
obfs-local -s 1.2.3.4 -p 80 -l 8388 --obfs http --http-method POST
```
The original request is `GET`, but it has a `Content-Length` header which is strange. `POST` or `PUT` may be better.