### PR TITLE
Fix FTBFS under GCC-9

### DIFF
--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -245,7 +245,7 @@ check_http_header(buffer_t *buf)
             }
 
         result = OBFS_ERROR;
-        if (strncasecmp(hostname, obfs_http->host, result) == 0) {
+        if (strncasecmp(hostname, obfs_http->host, len) == 0) {
             result = OBFS_OK;
         }
         free(hostname);


### PR DESCRIPTION
Resolve report from Debian:
 - https://bugs.debian.org/925829

obfs_http.c: In function 'check_http_header':
obfs_http.c:247:13: error: 'strncasecmp' specified bound
18446744073709551614 exceeds maximum object size 9223372036854775807
[-Werror=stringop-overflow=]
  247 |         if (strncasecmp(hostname, obfs_http->host, result) == 0)
{
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~