### PR TITLE
Convert arguments of isdigit to int.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -92,7 +92,7 @@ int
 ss_isnumeric(const char *s) {
     if (!s || !*s)
         return 0;
-    while (isdigit(*s))
+    while (isdigit((int)*s))
         ++s;
     return *s == '\0';
 }


### PR DESCRIPTION
Cygwin updated their GCC to version 9.2.0 recently and it now warns about passing chars to isdigit:

```
Making all in src
make[2]: Entering directory '/home/runneradmin/simple-obfs/src'
  CC       obfs_local-utils.o
In file included from utils.c:31:
utils.c: In function ‘ss_isnumeric’:
utils.c:95:20: error: array subscript has type ‘char’ [-Werror=char-subscripts]
   95 |     while (isdigit(*s))
      |                    ^~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:526: obfs_local-utils.o] Error 1
make[2]: Leaving directory '/home/runneradmin/simple-obfs/src'
make[1]: *** [Makefile:407: all-recursive] Error 1
make[1]: Leaving directory '/home/runneradmin/simple-obfs'
make: *** [Makefile:339: all] Error 2
```

While the warning message seems a bit misleading, this is because functions in Cygwin's `ctype.h` are deliberately defined to trigger these warnins:

https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/ctype.h;h=a0009af17485acc3d70586a0051269a7a9c350d5;hb=HEAD#l78

```c
/* These macros are intentionally written in a manner that will trigger
   a gcc -Wall warning if the user mistakenly passes a 'char' instead
   of an int containing an 'unsigned char'.  Note that the sizeof will
   always be 1, which is what we want for mapping EOF to __CTYPE_PTR[0];
   the use of a raw index inside the sizeof triggers the gcc warning if
   __c was of type char, and sizeof masks side effects of the extra __c.
   Meanwhile, the real index to __CTYPE_PTR+1 must be cast to int,
   since isalpha(0x100000001LL) must equal isalpha(1), rather than being
   an out-of-bounds reference on a 64-bit machine.  */
#define __ctype_lookup(__c) ((__CTYPE_PTR+sizeof(""[__c]))[(int)(__c)])

#define isalpha(__c)    (__ctype_lookup(__c)&(_U|_L))
#define isupper(__c)    ((__ctype_lookup(__c)&(_U|_L))==_U)
#define islower(__c)    ((__ctype_lookup(__c)&(_U|_L))==_L)
#define isdigit(__c)    (__ctype_lookup(__c)&_N)
#define isxdigit(__c)   (__ctype_lookup(__c)&(_X|_N))
#define isspace(__c)    (__ctype_lookup(__c)&_S)
#define ispunct(__c)    (__ctype_lookup(__c)&_P)
#define isalnum(__c)    (__ctype_lookup(__c)&(_U|_L|_N))
#define isprint(__c)    (__ctype_lookup(__c)&(_P|_U|_L|_N|_B))
#define isgraph(__c)    (__ctype_lookup(__c)&(_P|_U|_L|_N))
#define iscntrl(__c)    (__ctype_lookup(__c)&_C)
```