### PR TITLE
fix compile err by using newer gcc

### DIFF
--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -244,9 +244,10 @@ check_http_header(buffer_t *buf)
                 break;
             }
 
-        result = OBFS_ERROR;
         if (strncasecmp(hostname, obfs_http->host, len) == 0) {
             result = OBFS_OK;
+        } else {
+            result = OBFS_ERROR;
         }
         free(hostname);
         return result;


### PR DESCRIPTION
fix error: ‘strncasecmp’ specified bound 18446744073709551614 exceeds maximum object size